### PR TITLE
Updated example 10 includes temperature loads

### DIFF
--- a/examples/technology_showcase/example_10_td_055_Rotor_Blade_Inverse_solve.py
+++ b/examples/technology_showcase/example_10_td_055_Rotor_Blade_Inverse_solve.py
@@ -3,7 +3,7 @@
 Inverse-Solving Analysis of a Rotor Fan Blade with Disk
 ---------------------------------------------------------------------------------------
 Description:
-The NASA Rotor 67 fan bladed disk is a subsystem of a turbo fan’s compressor set used
+The NASA Rotor 67 fan bladed disk is a subsystem of a turbo fan compressor set used
 in aerospace engine applications. This sector model, representing a challenging industrial
 example for which the detailed geometry and flow information is available in the public
 domain, consists of a disk and a fan blade with a sector angle of 16.364 degrees.
@@ -94,6 +94,15 @@ cfx_data_path = download_file(
     "example_10_CFX_ExportResults_FT_10P_EO2.csv", "pymechanical", "embedding"
 )
 
+###############################################################################
+# Download required Temperature file
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Download the required files. Print the file path for the Temperature Data.
+
+temp_data_path = download_file(
+    "example_10_Temperature_Data.txt", "pymechanical", "embedding"
+)
+
 ###################################################################################
 # Configure graphics for image export
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -144,7 +153,7 @@ display_image("geometry.png")
 # Import material from xml file and assign it to bodies
 
 materials = ExtAPI.DataModel.Project.Model.Materials
-materials.Import(mat_path)
+# materials.Import(mat_path)
 
 PRT1 = [x for x in ExtAPI.DataModel.Tree.AllObjects if x.Name == "Component2\Rotor11"][
     0
@@ -153,10 +162,10 @@ PRT2 = [x for x in ExtAPI.DataModel.Tree.AllObjects if x.Name == "Component3"][0
 PRT2_Blade_1 = PRT2.Children[0]
 PRT2_Blade_2 = PRT2.Children[1]
 PRT2_Blade_3 = PRT2.Children[2]
-PRT1.Material = "MAT1 (Setup, File1)"
-PRT2_Blade_1.Material = "MAT1 (Setup, File1)"
-PRT2_Blade_2.Material = "MAT1 (Setup, File1)"
-PRT2_Blade_3.Material = "MAT1 (Setup, File1)"
+# PRT1.Material = "MAT1 (Setup, File1)"
+# PRT2_Blade_1.Material = "MAT1 (Setup, File1)"
+# PRT2_Blade_2.Material = "MAT1 (Setup, File1)"
+# PRT2_Blade_3.Material = "MAT1 (Setup, File1)"
 
 ###################################################################################
 # Define Units System and store variables
@@ -327,14 +336,14 @@ ExtAPI.Graphics.ExportImage(
 Model.AddStaticStructuralAnalysis()
 STAT_STRUC = Model.Analyses[0]
 ANA_SETTINGS = ExtAPI.DataModel.Project.Model.Analyses[0].AnalysisSettings
-ANA_SETTINGS.NumberOfSteps = 2
-ANA_SETTINGS.AutomaticTimeStepping = AutomaticTimeStepping.Off
-ANA_SETTINGS.NumberOfSubSteps = 20
-
+ANA_SETTINGS.AutomaticTimeStepping = AutomaticTimeStepping.On
+ANA_SETTINGS.NumberOfSubSteps = 10
 ANA_SETTINGS.Activate()
-ANA_SETTINGS.CurrentStepNumber = 2
-ANA_SETTINGS.AutomaticTimeStepping = AutomaticTimeStepping.Off
-ANA_SETTINGS.NumberOfSubSteps = 20
+
+CMD1 = STAT_STRUC.AddCommandSnippet()
+# Add convergence criterion using command snippet.
+AWM = """CNVTOL,U,1.0,5e-5,1,,"""
+CMD1.AppendText(AWM)
 
 ANA_SETTINGS.InverseOption = True
 ANA_SETTINGS.LargeDeflection = True
@@ -361,25 +370,83 @@ Fixed_Support = STAT_STRUC.AddFixedSupport()
 selection = NS_GRP.Children[3]
 Fixed_Support.Location = selection
 
-# Apply Thermal load to the Structural Blade
-Thermal_Condition = STAT_STRUC.AddThermalCondition()
-selection = NS_GRP.Children[1]
-Thermal_Condition.Location = selection
-Thermal_Condition.Magnitude.Inputs[0].DiscreteValues = [
-    Quantity("0 [s]"),
-    Quantity("1 [s]"),
-    Quantity("2 [s]"),
-]
-Thermal_Condition.Magnitude.Output.DiscreteValues = [
-    Quantity("22 [C]"),
-    Quantity("80 [C]"),
-    Quantity("80 [C]"),
-]
-
 ###################################################################################
 # Import CFX Pressure
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import CFX Pressure data and apply it to structural blade surface
+# Imported_Load_Group = STAT_STRUC.AddImportedLoadExternalData()
+
+# external_data_files = Ansys.Mechanical.ExternalData.ExternalDataFileCollection()
+# external_data_files.SaveFilesWithProject = False
+# external_data_file_1 = Ansys.Mechanical.ExternalData.ExternalDataFile()
+# external_data_files.Add(external_data_file_1)
+# external_data_file_1.Identifier = "File1"
+# external_data_file_1.Description = ""
+# external_data_file_1.IsMainFile = False
+# external_data_file_1.FilePath = cfx_data_path
+# external_data_file_1.ImportSettings = (
+# Ansys.Mechanical.ExternalData.ImportSettingsFactory.GetSettingsForFormat(
+# Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.ImportFormat.Delimited
+# )
+# )
+# import_settings = external_data_file_1.ImportSettings
+# import_settings.SkipRows = 17
+# import_settings.SkipFooter = 0
+# import_settings.Delimiter = ","
+# import_settings.AverageCornerNodesToMidsideNodes = False
+# import_settings.UseColumn(
+# 0,
+# Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.VariableType.XCoordinate,
+# "m",
+# "X Coordinate@A",
+# )
+# import_settings.UseColumn(
+# 1,
+# Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.VariableType.YCoordinate,
+# "m",
+# "Y Coordinate@B",
+# )
+# import_settings.UseColumn(
+# 2,
+# Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.VariableType.ZCoordinate,
+# "m",
+# "Z Coordinate@C",
+# )
+# import_settings.UseColumn(
+# 3,
+# Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.VariableType.Pressure,
+# "Pa",
+# "Pressure@D",
+# )
+
+# Imported_Load_Group.ImportExternalDataFiles(external_data_files)
+# Imported_Pressure = Imported_Load_Group.AddImportedPressure()
+# selection = NS_GRP.Children[2]
+# Imported_Pressure.Location = selection
+
+# pressure_id = Imported_Pressure.ObjectId
+# mech_command = f"""Imported_Pressure = ExtAPI.DataModel.GetObjectById({pressure_id})
+# Imported_Pressure.InternalObject.ExternalLoadAppliedBy = 1
+# """
+# app.execute_script(mech_command)
+
+# ## Supported in v24R1 build dated 20th september2023
+# #Imported_Pressure = ExtAPI.DataModel.GetObjectById(pressure_id)
+# #Imported_Pressure.AppliedBy = LoadAppliedBy.Direct
+# Imported_Pressure.ImportLoad()
+
+# Tree.Activate([Imported_Pressure])
+# ExtAPI.Graphics.Camera.SetFit()
+# ExtAPI.Graphics.ExportImage(
+#     os.path.join(cwd, "imported_pressure.png"), image_export_format, settings_720p
+# )
+# display_image("imported_pressure.png")
+
+###################################################################################
+# Import Temperature
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Import temperature data and apply it to structural blade
+
 Imported_Load_Group = STAT_STRUC.AddImportedLoadExternalData()
 
 external_data_files = Ansys.Mechanical.ExternalData.ExternalDataFileCollection()
@@ -389,14 +456,15 @@ external_data_files.Add(external_data_file_1)
 external_data_file_1.Identifier = "File1"
 external_data_file_1.Description = ""
 external_data_file_1.IsMainFile = False
-external_data_file_1.FilePath = cfx_data_path
+external_data_file_1.FilePath = temp_data_path
+
 external_data_file_1.ImportSettings = (
     Ansys.Mechanical.ExternalData.ImportSettingsFactory.GetSettingsForFormat(
         Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.ImportFormat.Delimited
     )
 )
 import_settings = external_data_file_1.ImportSettings
-import_settings.SkipRows = 17
+import_settings.SkipRows = 0
 import_settings.SkipFooter = 0
 import_settings.Delimiter = ","
 import_settings.AverageCornerNodesToMidsideNodes = False
@@ -420,22 +488,26 @@ import_settings.UseColumn(
 )
 import_settings.UseColumn(
     3,
-    Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.VariableType.Pressure,
-    "Pa",
-    "Pressure@D",
+    Ansys.Mechanical.DataModel.MechanicalEnums.ExternalData.VariableType.Temperature,
+    "C",
+    "Temperature@D",
 )
 
 Imported_Load_Group.ImportExternalDataFiles(external_data_files)
-Imported_Pressure = Imported_Load_Group.AddImportedPressure()
-selection = NS_GRP.Children[2]
-Imported_Pressure.Location = selection
+imported_body_temperature = Imported_Load_Group.AddImportedBodyTemperature()
 
-pressure_id = Imported_Pressure.ObjectId
-mech_command = f"""Imported_Pressure = ExtAPI.DataModel.GetObjectById({pressure_id})
-Imported_Pressure.InternalObject.ExternalLoadAppliedBy = 1
-"""
-app.execute_script(mech_command)
-Imported_Pressure.ImportLoad()
+selection = NS_GRP.Children[1]
+imported_body_temperature.Location = selection
+imported_load_id = imported_body_temperature.ObjectId
+imported_load = DataModel.GetObjectById(imported_load_id)
+imported_load.ImportLoad()
+
+Tree.Activate([imported_load])
+ExtAPI.Graphics.Camera.SetFit()
+ExtAPI.Graphics.ExportImage(
+    os.path.join(cwd, "imported_temperature.png"), image_export_format, settings_720p
+)
+display_image("imported_temperature.png")
 
 ###################################################################################
 # Postprocessing: Insert results objects
@@ -445,26 +517,14 @@ SOLN = STAT_STRUC.Solution
 TOT_DEF1 = SOLN.AddTotalDeformation()
 TOT_DEF1.DisplayTime = Quantity("1 [s]")
 
-TOT_DEF2 = SOLN.AddTotalDeformation()
-TOT_DEF2.DisplayTime = Quantity("2 [s]")
-
 EQV_STRS1 = SOLN.AddEquivalentStress()
 EQV_STRS1.DisplayTime = Quantity("1 [s]")
-
-EQV_STRS2 = SOLN.AddEquivalentStress()
-EQV_STRS2.DisplayTime = Quantity("2 [s]")
 
 EQV_TOT_STRN1 = SOLN.AddEquivalentTotalStrain()
 EQV_TOT_STRN1.DisplayTime = Quantity("1 [s]")
 
-EQV_TOT_STRN2 = SOLN.AddEquivalentTotalStrain()
-EQV_TOT_STRN2.DisplayTime = Quantity("2 [s]")
-
 THERM_STRN1 = SOLN.AddThermalStrain()
 THERM_STRN1.DisplayTime = Quantity("1 [s]")
-
-THERM_STRN2 = SOLN.AddThermalStrain()
-THERM_STRN2.DisplayTime = Quantity("2 [s]")
 
 ###################################################################################
 # Run Solution: Inverse Simulation
@@ -478,7 +538,7 @@ STAT_STRUC_SS = SOLN.Status
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Evaluate results, export screenshots
 
-Tree.Activate([TOT_DEF2])
+Tree.Activate([TOT_DEF1])
 ExtAPI.Graphics.ViewOptions.ResultPreference.ExtraModelDisplay = (
     Ansys.Mechanical.DataModel.MechanicalEnums.Graphics.ExtraModelDisplay.NoWireframe
 )
@@ -487,11 +547,17 @@ ExtAPI.Graphics.ExportImage(
 )
 display_image("deformation.png")
 
-Tree.Activate([EQV_STRS2])
+Tree.Activate([EQV_STRS1])
 ExtAPI.Graphics.ExportImage(
     os.path.join(cwd, "stress.png"), image_export_format, settings_720p
 )
 display_image("stress.png")
+
+Tree.Activate([THERM_STRN1])
+ExtAPI.Graphics.ExportImage(
+    os.path.join(cwd, "thermal_strain.png"), image_export_format, settings_720p
+)
+display_image("thermal_strain.png")
 
 ###################################################################################
 # Cleanup


### PR DESCRIPTION
Updated example 10 with the inclusion of temperature profile spatially varying over the blade and commented material.import() and imported pressure load (applied via internal objects usage) for now in v232 as it's not supported in Linux environment. However, in v24R1, we will uncomment and update the example. @dipinknair please review it and approve in order to publish in the documentation.