### PR TITLE
Maint: Increase timeout for doc build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
   doc-build:
     name: Documentation building
     runs-on: public-ubuntu-latest-8-cores
-    timeout-minutes: 15
+    timeout-minutes: 30
     container:
       image: ghcr.io/ansys/mechanical:24.1.0
       options: --entrypoint /bin/bash


### PR DESCRIPTION
Increasing time out action since it is taking more than 15 mins. It is because of additional examples recently added.