### PR TITLE
CHORE: Update main python version on ci/cd to 3.11

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.11'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci_cd_nightly.yml
+++ b/.github/workflows/ci_cd_nightly.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 3 * * *"
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.11'
   DEV_MAJOR_REV: '25'
   DEV_MINOR_REV: '2'
 


### PR DESCRIPTION
sphinx latest version supports only >=3.11